### PR TITLE
Add global CORS configuration

### DIFF
--- a/src/main/java/com/example/backendproject/config/WebConfig.java
+++ b/src/main/java/com/example/backendproject/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.example.backendproject.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig {
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("*")
+                        .allowedMethods("*");
+            }
+        };
+    }
+}

--- a/src/main/java/com/example/backendproject/security/SecurityConfig.java
+++ b/src/main/java/com/example/backendproject/security/SecurityConfig.java
@@ -13,7 +13,8 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http, UserDetailsService uds) throws Exception {
-        http.csrf().disable()
+        http.cors().and()
+                .csrf().disable()
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/", "/index.html", "/js/**", "/css/**", "/api/auth/**"


### PR DESCRIPTION
## Summary
- configure CORS support using `WebConfig`
- enable CORS in `SecurityConfig`

## Testing
- `mvn -q test` *(fails: Failed to initialize JPA EntityManagerFactory)*

------
https://chatgpt.com/codex/tasks/task_e_6850824b48a4832e9828afbeaea0d608